### PR TITLE
[Fix] gps 수신 안되는 거, 구조대 화면 들어갔다가 나오면 송수신 안되는 에러 수정

### DIFF
--- a/app/src/main/java/com/example/resqlink/MainActivity.kt
+++ b/app/src/main/java/com/example/resqlink/MainActivity.kt
@@ -24,6 +24,7 @@ import com.example.resqlink.domain.usecase.radar.RefreshMyLocationUsecase
 import com.example.resqlink.domain.usecase.radar.SetRadarModeUsecase
 import com.example.resqlink.domain.usecase.reach.ReachControlUseCase
 import com.example.resqlink.platform.location.AndroidLocationProvider
+import com.example.resqlink.platform.logging.FileRssiDistanceLogger
 import com.example.resqlink.platform.reach.dedup.InMemoryDedupStore
 import com.example.resqlink.platform.reach.protocol.MessageCodec
 import com.example.resqlink.platform.reach.receiver.ReachReceiver
@@ -209,10 +210,12 @@ class MainActivity : ComponentActivity() {
         val locationProvider = AndroidLocationProvider(this)
         val store = InMemoryRadarStateStore()
 
+        val rssiLogger = FileRssiDistanceLogger(this)
         val applyIncomingSos = ApplyIncomingSosUsecase(
             store = store,
             locationProvider = locationProvider,
-            mySenderId = mySenderId
+            mySenderId = mySenderId,
+            rssiDistanceLogger = rssiLogger
         )
 
         val receiver = ReachReceiver(

--- a/app/src/main/java/com/example/resqlink/data/store/InMemoryRadarStateStore.kt
+++ b/app/src/main/java/com/example/resqlink/data/store/InMemoryRadarStateStore.kt
@@ -29,7 +29,7 @@ class InMemoryRadarStateStore(
 ): RadarStateStore {
     private val estimator = RssiRangeEstimator(rssiCfg)
 
-    private val _mode = MutableStateFlow(RadarMode.GPS_OFF)
+    private val _mode = MutableStateFlow(RadarMode.GPS_ON)
     override val mode: StateFlow<RadarMode> = _mode.asStateFlow()
 
     private val _targets = MutableStateFlow<List<RadarTarget>>(emptyList())
@@ -51,6 +51,8 @@ class InMemoryRadarStateStore(
     private val lock = Any()
     private val byOrigin = linkedMapOf<String, Entry>()
     private var myLoc: GeoLocation? = null
+
+    override fun getMyLocation(): GeoLocation? = myLoc
 
     override fun setMode(mode: RadarMode) {
         _mode.value = mode

--- a/app/src/main/java/com/example/resqlink/data/store/RadarStateStore.kt
+++ b/app/src/main/java/com/example/resqlink/data/store/RadarStateStore.kt
@@ -15,6 +15,9 @@ interface RadarStateStore {
 
     fun setMode(mode: RadarMode)
 
+    /** GPS 폴링으로 저장된 내 위치. getCurrentLocation() 실패 시 폴백용 */
+    fun getMyLocation(): GeoLocation?
+
     fun onIncomingSos(
         originId: String,
         msgId: String,

--- a/app/src/main/java/com/example/resqlink/domain/gateway/RssiDistanceLogger.kt
+++ b/app/src/main/java/com/example/resqlink/domain/gateway/RssiDistanceLogger.kt
@@ -1,0 +1,14 @@
+package com.example.resqlink.domain.gateway
+
+/**
+ * GPS 기반 실제 거리와 RSSI를 로컬에 기록하여
+ * 나중에 학습/검증 데이터로 활용하기 위한 인터페이스.
+ */
+interface RssiDistanceLogger {
+    /**
+     * actualDistanceM: GPS로 계산한 실제 거리(미터)
+     * rssiDbm: 해당 시점의 수신 신호 강도
+     * timestampMs: 기록 시각
+     */
+    fun log(actualDistanceM: Double, rssiDbm: Int, timestampMs: Long)
+}

--- a/app/src/main/java/com/example/resqlink/domain/usecase/radar/ApplyIncomingSosUsecase.kt
+++ b/app/src/main/java/com/example/resqlink/domain/usecase/radar/ApplyIncomingSosUsecase.kt
@@ -3,8 +3,8 @@ package com.example.resqlink.domain.usecase.radar
 import android.util.Log
 import com.example.resqlink.data.store.RadarStateStore
 import com.example.resqlink.domain.gateway.GeoLocation
+import com.example.resqlink.domain.gateway.RssiDistanceLogger
 import com.example.resqlink.domain.gateway.LocationProvider
-import com.example.resqlink.domain.model.radar.RadarMode
 import com.example.resqlink.domain.model.sos.IncomingSosEvent
 import com.example.resqlink.platform.reach.protocol.MessageEnvelope
 import com.example.resqlink.platform.reach.protocol.MessageType
@@ -15,7 +15,8 @@ import kotlinx.coroutines.flow.SharedFlow
 class ApplyIncomingSosUsecase(
     private val store: RadarStateStore,
     private val locationProvider: LocationProvider,
-    private val mySenderId: String
+    private val mySenderId: String,
+    private val rssiDistanceLogger: RssiDistanceLogger? = null
 ) {
 
     private val _incomingSosEvents =
@@ -47,12 +48,24 @@ class ApplyIncomingSosUsecase(
                 GeoLocation(payload.lat, payload.lng)
             else null
         Log.d("ResQLink_Apply", "📍 [좌표수신] Lat: ${payload.lat}, Lng: ${payload.lng}")
-        val myLoc =
-            if (store.mode.value == RadarMode.GPS_ON)
-                locationProvider.getCurrentLocation()
-            else null
+        // Radar 진입 여부와 무관하게, 내 위치 + payload 위치 있으면 GPS 거리 계산
+        val myLoc = locationProvider.getCurrentLocation() ?: store.getMyLocation()
         Log.d("ResQLink_Distance", "📍 내 위치: $myLoc, 상대 위치: $payloadLoc, 모드: ${store.mode.value}")
 
+        // GPS 둘 다 있으면 (실제거리, RSSI) 로깅 → 학습/검증 데이터 수집
+        if (payloadLoc != null && myLoc != null && rssiDbm != null) {
+            val results = FloatArray(1)
+            android.location.Location.distanceBetween(
+                myLoc.lat, myLoc.lng,
+                payloadLoc.lat, payloadLoc.lng,
+                results
+            )
+            rssiDistanceLogger?.log(
+                actualDistanceM = results[0].toDouble(),
+                rssiDbm = rssiDbm,
+                timestampMs = envelope.timestampMs
+            )
+        }
 
         store.onIncomingSos(
             originId = originId,

--- a/app/src/main/java/com/example/resqlink/platform/location/AndroidLocationProvider.kt
+++ b/app/src/main/java/com/example/resqlink/platform/location/AndroidLocationProvider.kt
@@ -6,9 +6,12 @@ import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import com.example.resqlink.domain.gateway.GeoLocation
 import com.example.resqlink.domain.gateway.LocationProvider
+import com.google.android.gms.location.Priority
 import com.google.android.gms.location.LocationServices
-import kotlinx.coroutines.suspendCancellableCoroutine
+import com.google.android.gms.tasks.CancellationTokenSource
+import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 class AndroidLocationProvider(
     private val context: Context
@@ -27,9 +30,15 @@ class AndroidLocationProvider(
 
         if (!hasPermission) return null
 
-        // 2️⃣ 마지막 위치 가져오기 (빠르고 안정적)
         return suspendCancellableCoroutine { cont ->
-            client.lastLocation
+            val cts = CancellationTokenSource()
+            cont.invokeOnCancellation { cts.cancel() }
+
+            // 2️⃣ getCurrentLocation: 캐시 없어도 새 위치 요청 (최대 ~15초 대기)
+            client.getCurrentLocation(
+                Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                cts.token
+            )
                 .addOnSuccessListener { location ->
                     if (location != null) {
                         cont.resume(
@@ -39,12 +48,32 @@ class AndroidLocationProvider(
                             )
                         )
                     } else {
-                        cont.resume(null)
+                        // 3️⃣ null이면 lastLocation 캐시 폴백
+                        tryLastLocation(cont)
                     }
                 }
                 .addOnFailureListener {
-                    cont.resume(null)
+                    tryLastLocation(cont)
                 }
         }
+    }
+
+    private fun tryLastLocation(cont: Continuation<GeoLocation?>) {
+        client.lastLocation
+            .addOnSuccessListener { location ->
+                if (location != null) {
+                    cont.resume(
+                        GeoLocation(
+                            lat = location.latitude,
+                            lng = location.longitude
+                        )
+                    )
+                } else {
+                    cont.resume(null)
+                }
+            }
+            .addOnFailureListener {
+                cont.resume(null)
+            }
     }
 }

--- a/app/src/main/java/com/example/resqlink/platform/logging/FileRssiDistanceLogger.kt
+++ b/app/src/main/java/com/example/resqlink/platform/logging/FileRssiDistanceLogger.kt
@@ -1,0 +1,40 @@
+package com.example.resqlink.platform.logging
+
+import android.content.Context
+import android.util.Log
+import com.example.resqlink.domain.gateway.RssiDistanceLogger
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * actualDistanceM, rssiDbm을 로컬 CSV 파일에 append.
+ * 학습/검증용 데이터 수집.
+ */
+class FileRssiDistanceLogger(
+    private val context: Context
+) : RssiDistanceLogger {
+
+    private val logFile: File
+        get() = File(context.filesDir, FILE_NAME)
+
+    override fun log(actualDistanceM: Double, rssiDbm: Int, timestampMs: Long) {
+        try {
+            val file = logFile
+            if (!file.exists()) {
+                file.writeText("actualDistanceM,rssiDbm,timestampMs\n", StandardCharsets.UTF_8)
+            }
+            val line = "$actualDistanceM,$rssiDbm,$timestampMs\n"
+            FileOutputStream(file, true).use { fos ->
+                fos.write(line.toByteArray(StandardCharsets.UTF_8))
+            }
+            Log.d("ResQLink_RssiLog", "logged: dist=${actualDistanceM}m, rssi=$rssiDbm")
+        } catch (e: Exception) {
+            Log.e("ResQLink_RssiLog", "write failed: ${e.message}")
+        }
+    }
+
+    companion object {
+        private const val FILE_NAME = "rssi_distance_log.csv"
+    }
+}

--- a/app/src/main/java/com/example/resqlink/ui/feature_responder/RadarScreen.kt
+++ b/app/src/main/java/com/example/resqlink/ui/feature_responder/RadarScreen.kt
@@ -256,11 +256,20 @@ private fun RadarCircleChart(
     val unknown = remember(signals) { signals.filter { it.bucket == com.example.resqlink.domain.model.Range.RangeBucket.UNKNOWN } }
 
     // 배치: bearing 있으면 각도대로, 없으면 “원형에서 임의 각도(고정)”로
-    fun radiusFor(bucket: com.example.resqlink.domain.model.Range.RangeBucket): Float = when (bucket) {
-        com.example.resqlink.domain.model.Range.RangeBucket.NEAR -> nearR
-        com.example.resqlink.domain.model.Range.RangeBucket.MID -> midR
-        com.example.resqlink.domain.model.Range.RangeBucket.FAR -> farR
-        com.example.resqlink.domain.model.Range.RangeBucket.UNKNOWN -> farR
+    val maxDistanceM = 200f
+    fun radiusFor(signal: RadarSignalUi): Float {
+        val distanceM = signal.distanceM
+        return if (distanceM != null && distanceM > 0) {
+            val fraction = (distanceM.toFloat() / maxDistanceM).coerceIn(0f, 1f)
+            fraction * farR  // 0m=center, 200m=farR (가까울수록 줌)
+        } else {
+            when (signal.bucket) {
+                com.example.resqlink.domain.model.Range.RangeBucket.NEAR -> nearR
+                com.example.resqlink.domain.model.Range.RangeBucket.MID -> midR
+                com.example.resqlink.domain.model.Range.RangeBucket.FAR -> farR
+                com.example.resqlink.domain.model.Range.RangeBucket.UNKNOWN -> farR
+            }
+        }
     }
 
     Box(Modifier.fillMaxSize()) {
@@ -291,9 +300,9 @@ private fun RadarCircleChart(
         val dotSize = 14.dp
         val dotPx = with(density) { dotSize.toPx() }
 
-        // known: bearing 있으면 그 각도, 없으면 key 기반 각도
+        // known: bearing 있으면 그 각도, 없으면 key 기반 각도. distanceM 있으면 실제 거리 비례 반지름
         known.forEach { s ->
-            val r = radiusFor(s.bucket)
+            val r = radiusFor(s)
             val angle = (s.bearingDeg ?: stableAngleDeg(s.key)).toRadians()
             val x = cx + (r * cos(angle)).toFloat()
             val y = cy - (r * sin(angle)).toFloat()

--- a/app/src/main/java/com/example/resqlink/ui/feature_responder/RadarViewModel.kt
+++ b/app/src/main/java/com/example/resqlink/ui/feature_responder/RadarViewModel.kt
@@ -39,7 +39,8 @@ class RadarViewModel(
                         bucket = target.bucket,
                         bearingDeg = target.bearingDeg,
                         displayRange = "약 ${target.approxRangeText}",
-                        lastSeenMs = target.lastSeenMs
+                        lastSeenMs = target.lastSeenMs,
+                        distanceM = target.distanceM
                     )
                 },
                 selectedKey = selectedKey
@@ -66,7 +67,7 @@ class RadarViewModel(
     fun onExitScreen() {
         stopGpsPolling()
         // “화면 나가면 종료” 정책일 때만!
-        reachControl.stopReachMode()
+        // reachControl.stopReachMode() // Radar 나가도 송수신 유지
     }
 
     fun onToggleGps(enabled: Boolean) {


### PR DESCRIPTION
- SOS 받을 때 자신의 위치가 저장된 것이 없으면 자신의 위치를 새로 받아와 gps 거리 계산 (gps 켜도 null로 뜨던 것 해결)
- 구조대 화면 들어갔다 나오면 nearby 통신 끄기 옵션 제거 
- GPS가 되는 환경이면 구조대 화면 들어가면 바로 GPS_ON 모드가 보이도록 수정
- 거리에 비례하게 위치가 뜨도록 수정 (원래는 선 경계에만 떴음)